### PR TITLE
add props to dataset and pipelines + small fix to cacher

### DIFF
--- a/fuse/data/datasets/caching/samples_cacher.py
+++ b/fuse/data/datasets/caching/samples_cacher.py
@@ -207,14 +207,16 @@ class SamplesCacher:
             orig_sid_to_final[initial_sample_id] = output_sample_ids
 
         write_dir = self._get_write_dir()
+
+        set_info_dir = os.path.join(write_dir, "full_sets_info")
+        os.makedirs(set_info_dir, exist_ok=True)
+
         pipeline_desc_file = os.path.join(write_dir, f"pipeline_{self._pipeline_desc_hash}_desc.txt")
         if not os.path.exists(pipeline_desc_file):
             with open(pipeline_desc_file, "wt") as f:
                 f.write(self._pipeline_desc_text)
             print("======== wrote", pipeline_desc_file)
 
-        set_info_dir = os.path.join(write_dir, "full_sets_info")
-        os.makedirs(set_info_dir, exist_ok=True)
         fullpath_filename = os.path.join(set_info_dir, hash_filename)
         save_pickle_safe(orig_sid_to_final, fullpath_filename, compress=True)
 

--- a/fuse/data/datasets/dataset_default.py
+++ b/fuse/data/datasets/dataset_default.py
@@ -113,6 +113,14 @@ class DatasetDefault(DatasetBase):
 
         self._created = False
 
+    @property
+    def static_pipeline(self):
+        return self._static_pipeline
+
+    @property
+    def dynamic_pipeline(self):
+        return self._dynamic_pipeline
+
     def create(self, num_workers: int = 0, mp_context: Optional[str] = None) -> None:
         """
         Create the data set, including caching

--- a/fuse/data/pipelines/pipeline_default.py
+++ b/fuse/data/pipelines/pipeline_default.py
@@ -56,6 +56,10 @@ class PipelineDefault(OpReversibleBase):
             self._op_ids = op_ids
         self._verbose = verbose
 
+    @property
+    def ops(self):
+        return [a[0] for a in self._ops_and_kwargs]
+
     def copy(self):
         """
         This is a shallow copy of the pipeline: the two pipelines will point to the same operation instances.

--- a/fuse/utils/ndict.py
+++ b/fuse/utils/ndict.py
@@ -23,7 +23,7 @@ import copy
 import types
 import numpy
 import torch
-from typing import Any, Callable, Iterator, Optional, Sequence, Union, List
+from typing import Any, Callable, Iterator, Optional, Sequence, Union, List, MutableMapping
 
 
 class NDict(dict):
@@ -73,7 +73,7 @@ class NDict(dict):
         elif isinstance(dict_like, NDict):
             self._stored = dict_like._stored
         else:
-            if not isinstance(dict_like, dict):
+            if not isinstance(dict_like, MutableMapping):
                 dict_like = dict(dict_like)
             for k, d in dict_like.items():
                 self[k] = d
@@ -114,7 +114,7 @@ class NDict(dict):
 
         all_keys = {}
         for key in self._stored:
-            if isinstance(self._stored[key], dict):
+            if isinstance(self._stored[key], MutableMapping):
                 all_sub_keys = NDict(self[key]).flatten()
                 keys_to_add = {f"{key}.{sub_key}": all_sub_keys[sub_key] for sub_key in all_sub_keys}
                 all_keys.update(keys_to_add)
@@ -163,7 +163,7 @@ class NDict(dict):
 
         value = self._stored
         for sub_key in nested_key:
-            if isinstance(value, dict) and sub_key in value:
+            if isinstance(value, MutableMapping) and sub_key in value:
                 value = value.get(sub_key)
             else:
                 raise NestedKeyError(key, self)
@@ -177,7 +177,7 @@ class NDict(dict):
         :param value: value to set
         """
         # if value is dictionary add to self key by key to avoid from keys with delimeter "."
-        if isinstance(value, dict):
+        if isinstance(value, MutableMapping):
             for sub_key in value:
                 self[f"{key}.{sub_key}"] = value[sub_key]
             return
@@ -211,7 +211,7 @@ class NDict(dict):
         partial_ndict = self._stored
         parts = key.split(".")
         for k in parts:
-            if isinstance(partial_ndict, dict) and k in partial_ndict:
+            if isinstance(partial_ndict, MutableMapping) and k in partial_ndict:
                 partial_key.append(k)
                 partial_ndict = partial_ndict[k]
             else:


### PR DESCRIPTION
1. I added these properties to allow easy access to operation objects in UKBB dataset's pipelines. 
In my case, I used it to retrieve the number of features from a "dataframe loading operation". After the dataset was created this operation stored the number of features in one of its internal field members.

2. small fix for cacher - moved the writing of the pipeline description after the creation of the directory