### PR TITLE
Make `op_id` a really optional argument in `OpCast`

### DIFF
--- a/fuse/data/ops/ops_cast.py
+++ b/fuse/data/ops/ops_cast.py
@@ -163,8 +163,8 @@ class OpCast(OpReversibleBase):
     def __call__(
         self,
         sample_dict: NDict,
-        op_id: Optional[str],
         key: Union[str, Sequence[str]],
+        op_id: Optional[str] = None,
         **kwargs: dict,
     ) -> Union[None, dict, List[dict]]:
         """


### PR DESCRIPTION
Minor change for a small thing that had annoyed me for a while :)

Note, this doesn't affect the pipelines (static & dynamic), rather working with ops as a mere objects.
For example:

```python
from fuse.data import OpToTensor

# Assuming sample_dict is an 'NDict' with a key 'key' 

op = OpToTensor()
op(sample_dict, key="key", op_id=None)   # Must set op_id to some value although it's an optional 
op(sample_dict, key="key")   # After merging this PR :)
```

Mostly relevant for unit-testing.