### PR TITLE
MetricCountSeqAndTokens counst tokens in label (if exist) + improving epoch metrics print

### DIFF
--- a/fuse/data/ops/op_base.py
+++ b/fuse/data/ops/op_base.py
@@ -135,7 +135,7 @@ def op_call(
             + f"error in __call__ method of op={op}, op_id={op_id}, sample_id={get_sample_id(sample_dict)} - more details below"
             + "*************************************************************************************************************************************\n"
         )
-        print(traceback.print_exc())
+        traceback.print_exc()
         raise
 
 

--- a/fuse/data/ops/op_base.py
+++ b/fuse/data/ops/op_base.py
@@ -22,6 +22,7 @@ from fuse.data.utils.sample import get_sample_id
 from fuse.utils.ndict import NDict
 from fuse.data.ops.hashable_class import HashableClass
 import inspect
+import traceback
 
 
 class OpBase(HashableClass):
@@ -134,6 +135,7 @@ def op_call(
             + f"error in __call__ method of op={op}, op_id={op_id}, sample_id={get_sample_id(sample_dict)} - more details below"
             + "*************************************************************************************************************************************\n"
         )
+        print(traceback.print_exc())
         raise
 
 

--- a/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
+++ b/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
@@ -40,7 +40,7 @@ class MetricCountSeqAndTokens(MetricPerBatchDefault):
     ) -> None:
         """
         :param encoder_input: key to the encoder_input
-        :param decoder_input: key to the encoder_input
+        :param decoder_input: key to the decoder_input
         :param ignore_index: token_id to ignore (not to count), typically pad token id
         :param state: the sequence count and token count to continue for. Should be restored when we continue training.
                     use get_state() to get the state and save it upon checkpointing,

--- a/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
+++ b/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
@@ -203,7 +203,7 @@ def _perplexity_update(
         preds = preds[mask]
         count = mask.sum()
     else:
-        count = target.shape[0]
+        count = torch.tensor(target.shape[0])
 
     preds = torch.gather(preds, 1, target.view(-1, 1)).squeeze(1)
     # avoid from overflow
@@ -211,7 +211,6 @@ def _perplexity_update(
         preds = preds.to(torch.float32)
         preds = torch.clamp(preds, min=1e-10)
     total_log_probs = -preds.log().sum()
-    count = mask.sum()
 
     return {"log_probs": total_log_probs.unsqueeze(0), "token_num": count.unsqueeze(0)}
 

--- a/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
+++ b/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
@@ -194,8 +194,10 @@ def _perplexity_update(
     preds = preds.detach()
     target = target.detach()
 
-    preds = preds.view(-1, preds.shape[-1])
-    target = target.view(-1)
+    # reshape attempts to create a view, and COPIES the data if fails.
+    # an issue to consider:  use view and alert the user if it fails?
+    preds = preds.reshape(-1, preds.shape[-1])
+    target = target.reshape(-1)
 
     if ignore_index is not None:
         mask = target.ne(ignore_index)

--- a/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
+++ b/fuse/eval/metrics/sequence_gen/metrics_seq_gen_common.py
@@ -93,7 +93,7 @@ def _count_seq_and_tokens_update(
         encoder_input_key:
             key to encoder_input
         decoder_input_key:
-            key to encoder_input
+            key to decoder_input
         ignore_index:
             Token not to count, typically padding
     Returns:

--- a/fuse/utils/misc/misc.py
+++ b/fuse/utils/misc/misc.py
@@ -158,22 +158,22 @@ def time_display(seconds: int, granularity: int = 3) -> str:
 
 def get_pretty_dataframe(df: pd.DataFrame, col_width: int = 25) -> str:
     # check is col_width needs to be widen (so that dashes are in one line)
-    max_val_width = np.vectorize(len)(
-        df.values.astype(str)
-    ).max()  # get maximum length of all values
-    max_col_width = max(
-        [len(x) for x in df.columns]
-    )  # get the maximum lengths of all column names
-    col_width = max(max_col_width, max_val_width, col_width)
+    max_val_width_per_col = np.vectorize(len)(df.values.astype(str)).max(
+        axis=0
+    )  # get maximum length of all values
+    col_name_widths = [len(x) for x in df.columns]  # get column names length
+    col_widths = [
+        max(max(x), col_width) for x in zip(max_val_width_per_col, col_name_widths)
+    ]
 
-    dashes = (col_width + 2) * len(df.columns.values)
+    dashes = sum(col_widths) + 2 * len(df.columns.values)
     df_as_string = f"\n{'-' * dashes}\n"
-    for col in df.columns.values:
-        df_as_string += f"| {col:{col_width}}"
+    for col, col_w in zip(df.columns.values, col_widths):
+        df_as_string += f"| {col:{col_w}}"
     df_as_string += f"|\n{'-' * dashes}\n"
     for idx, row in df.iterrows():
-        for col in df.columns.values:
-            df_as_string += f"| {row[col]:{col_width}}"
+        for i_col, col in enumerate(df.columns.values):
+            df_as_string += f"| {row[col]:{col_widths[i_col]}}"
 
         df_as_string += f"|\n{'-' * dashes}\n"
     return df_as_string


### PR DESCRIPTION
1. add optional decoder_input to MetricCountSeqAndTokens
2. print traceback before throw - helps in debugging
3. modify epoch stats printing - each column has its own (fixed) width