### PR TITLE
Matching keys lengths and new metrics

### DIFF
--- a/fuse/data/utils/collates.py
+++ b/fuse/data/utils/collates.py
@@ -66,12 +66,7 @@ class CollateDefault(CollateToBatchList):
         self._keep_keys = keep_keys
         self._add_to_batch_dict = add_to_batch_dict
 
-        self._post_collate_special_handlers_keys = None
-        if post_collate_special_handlers_keys is not None:
-            self._post_collate_special_handlers_keys = {}
-            self._post_collate_special_handlers_keys.update(
-                post_collate_special_handlers_keys
-            )
+        self._post_collate_special_handlers_keys = post_collate_special_handlers_keys
 
     def __call__(self, samples: List[Dict]) -> Dict:
         """
@@ -117,8 +112,8 @@ class CollateDefault(CollateToBatchList):
             batch_dict.update(self._add_to_batch_dict)
 
         if self._post_collate_special_handlers_keys is not None:
-            for key in self._post_collate_special_handlers_keys:
-                self._post_collate_special_handlers_keys[keys](batch_dict)
+            for callable in self._post_collate_special_handlers_keys:
+                callable(batch_dict)
 
         return batch_dict
 

--- a/fuse/data/utils/collates.py
+++ b/fuse/data/utils/collates.py
@@ -257,7 +257,7 @@ class CollateDefault(CollateToBatchList):
         return batched_sequences
 
     @staticmethod
-    def match_length_to_target_key(
+    def crop_length_to_match_target_key(
         batch_dict: dict, target_key: str, keys_to_match: List[str]
     ) -> None:
         """

--- a/fuse/data/utils/collates.py
+++ b/fuse/data/utils/collates.py
@@ -43,6 +43,7 @@ class CollateDefault(CollateToBatchList):
         keep_keys: Sequence[str] = tuple(),
         raise_error_key_missing: bool = True,
         special_handlers_keys: Optional[Dict[str, Callable]] = None,
+        post_collate_special_handlers_keys: Optional[List[Callable]] = None,
         add_to_batch_dict: Optional[Dict[str, Any]] = None,
     ):
         """
@@ -51,6 +52,7 @@ class CollateDefault(CollateToBatchList):
         :param special_handlers_keys: per key specify a callable which gets as an input list of values and convert it to a batch.
                                       The rest of the keys will be converted to batch using PyTorch default collate_fn()
                                       Example of such Callable can be seen in the CollateDefault.pad_all_tensors_to_same_size.
+        :param post_collate_special_handlers_keys: specify a callable which gets the batch_dict as an input and applies post processing to the batched tensors.
         :param raise_error_key_missing: if False, will not raise an error if there are keys that do not exist in some of the samples. Instead will set those values to None.
         :param add_to_batch_dict: optional, fixed items to add to batch_dict
         """
@@ -63,6 +65,13 @@ class CollateDefault(CollateToBatchList):
         ] = CollateDefault.just_collect_to_list
         self._keep_keys = keep_keys
         self._add_to_batch_dict = add_to_batch_dict
+
+        self._post_collate_special_handlers_keys = None
+        if post_collate_special_handlers_keys is not None:
+            self._post_collate_special_handlers_keys = {}
+            self._post_collate_special_handlers_keys.update(
+                post_collate_special_handlers_keys
+            )
 
     def __call__(self, samples: List[Dict]) -> Dict:
         """
@@ -106,6 +115,10 @@ class CollateDefault(CollateToBatchList):
 
         if self._add_to_batch_dict is not None:
             batch_dict.update(self._add_to_batch_dict)
+
+        if self._post_collate_special_handlers_keys is not None:
+            for key in self._post_collate_special_handlers_keys:
+                self._post_collate_special_handlers_keys[keys](batch_dict)
 
         return batch_dict
 
@@ -229,3 +242,22 @@ class CollateDefault(CollateToBatchList):
         cropped_sequences = [ids[:min_length] for ids in input_ids_list]
         batched_sequences = torch.stack(cropped_sequences, dim=0)
         return batched_sequences
+
+    @staticmethod
+    def match_length_to_target_key(
+        batch_dict: dict, target_key: str, keys_to_match: List[str]
+    ) -> None:
+        """
+        Match the 1st dimension (typically the sequence length) of tensors in batch_dict, specified by keys, to a target tensor.
+
+        Args:
+            :param batch_dict: input dictionary with batched tensors with expected shape (B, L, *) where B is the batch dimension and L is a sequential dimension. L may vary across the elements in the batch_dict. * is any number of additional dimensions.
+            :param target_key: key in batch_dict of the tensors with desired sequential dimension, L'.
+            :param keys_to_match: list of keys in batch_dict with tensors who's 1st dimension should be converted to match the target_key tensor. The tensors to match should have 1st dimenions L >= L'.
+
+        Returns:
+            None, elements are modified in the batch_dict.
+        """
+        target_length = batch_dict[target_key].shape[1]
+        for key in keys_to_match:
+            batch_dict[key] = batch_dict[key][:, :target_length]

--- a/fuse/eval/metrics/classification/metrics_classification_common.py
+++ b/fuse/eval/metrics/classification/metrics_classification_common.py
@@ -365,9 +365,9 @@ class MetricMCC(MetricDefault):
 
     def mcc_wrapper(
         self,
-        pred: Optional[str] = None,
-        target: Optional[str] = None,
-        sample_weight: Optional[str] = None,
+        pred: Union[List, np.ndarray],
+        target: Union[List, np.ndarray],
+        sample_weight: Optional[Union[List, np.ndarray, None]] = None,
         **kwargs: dict,
     ) -> float:
         """
@@ -404,9 +404,9 @@ class MetricBalAccuracy(MetricDefault):
 
     def balanced_acc_wrapper(
         self,
-        pred: Optional[str] = None,
-        target: Optional[str] = None,
-        sample_weight: Optional[str] = None,
+        pred: Union[List, np.ndarray],
+        target: Union[List, np.ndarray],
+        sample_weight: Optional[Union[List, np.ndarray, None]] = None,
         **kwargs: dict,
     ) -> float:
         """

--- a/fuse/eval/metrics/classification/metrics_classification_common.py
+++ b/fuse/eval/metrics/classification/metrics_classification_common.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from fuse.eval.metrics.metrics_common import MetricDefault, MetricWithCollectorBase
 from fuse.eval.metrics.libs.classification import MetricsLibClass
+from sklearn.metrics import matthews_corrcoef, balanced_accuracy_score
 
 
 class MetricMultiClassDefault(MetricWithCollectorBase):
@@ -336,3 +337,81 @@ class MetricBSS(MetricDefault):
             metric_func=MetricsLibClass.multi_class_bss,
             **kwargs,
         )
+
+
+class MetricMCC(MetricDefault):
+    """
+    Compute Mathews correlation coef for predictions
+    """
+
+    def __init__(
+        self,
+        pred: Optional[str] = None,
+        target: Optional[str] = None,
+        sample_weight: Optional[str] = None,
+        **kwargs: dict,
+    ):
+        """
+        See MetricDefault for the missing params
+        :param sample_weight: weight per sample for the final accuracy score. Keep None if not required.
+        """
+        super().__init__(
+            pred=pred,
+            target=target,
+            sample_weight=sample_weight,
+            metric_func=self.mcc_wrapper,
+            **kwargs,
+        )
+
+    def mcc_wrapper(
+        self,
+        pred: Optional[str] = None,
+        target: Optional[str] = None,
+        sample_weight: Optional[str] = None,
+        **kwargs: dict,
+    ) -> float:
+        """
+        for matching MetricDefault expected input format to that of sklearn
+        """
+        res_dict = {"y_true": target, "y_pred": pred, "sample_weight": sample_weight}
+        score = matthews_corrcoef(**res_dict)
+        return score
+
+
+class MetricBalAccuracy(MetricDefault):
+    """
+    Compute Balanced accuracy for predictions
+    """
+
+    def __init__(
+        self,
+        pred: Optional[str] = None,
+        target: Optional[str] = None,
+        sample_weight: Optional[str] = None,
+        **kwargs: dict,
+    ):
+        """
+        See MetricDefault for the missing params
+        :param sample_weight: weight per sample for the final accuracy score. Keep None if not required.
+        """
+        super().__init__(
+            pred=pred,
+            target=target,
+            sample_weight=sample_weight,
+            metric_func=self.balanced_acc_wrapper,
+            **kwargs,
+        )
+
+    def balanced_acc_wrapper(
+        self,
+        pred: Optional[str] = None,
+        target: Optional[str] = None,
+        sample_weight: Optional[str] = None,
+        **kwargs: dict,
+    ) -> float:
+        """
+        for matching MetricDefault expected input format to that of sklearn
+        """
+        res_dict = {"y_true": target, "y_pred": pred, "sample_weight": sample_weight}
+        score = balanced_accuracy_score(**res_dict)
+        return score

--- a/fuse/eval/metrics/classification/metrics_classification_common.py
+++ b/fuse/eval/metrics/classification/metrics_classification_common.py
@@ -353,6 +353,8 @@ class MetricMCC(MetricDefault):
     ):
         """
         See MetricDefault for the missing params
+        :param pred: class label predictions
+        :param target: ground truth labels
         :param sample_weight: weight per sample for the final accuracy score. Keep None if not required.
         """
         super().__init__(
@@ -392,6 +394,8 @@ class MetricBalAccuracy(MetricDefault):
     ):
         """
         See MetricDefault for the missing params
+        :param pred: class label predictions
+        :param target: ground truth labels
         :param sample_weight: weight per sample for the final accuracy score. Keep None if not required.
         """
         super().__init__(

--- a/fuse/eval/metrics/metrics_common.py
+++ b/fuse/eval/metrics/metrics_common.py
@@ -160,7 +160,10 @@ class MetricCollector(MetricBase):
             batch_to_collect = {}
 
             for name, key in self._keys_to_collect.items():
-                value = batch[key]
+                try:
+                    value = batch[key]
+                except:
+                    print(self._keys_to_collect)
 
                 # collect distributed
                 if dist.is_initialized() and self._collect_distributed:

--- a/fuse/eval/metrics/metrics_common.py
+++ b/fuse/eval/metrics/metrics_common.py
@@ -160,10 +160,7 @@ class MetricCollector(MetricBase):
             batch_to_collect = {}
 
             for name, key in self._keys_to_collect.items():
-                try:
-                    value = batch[key]
-                except:
-                    print(self._keys_to_collect)
+                value = batch[key]
 
                 # collect distributed
                 if dist.is_initialized() and self._collect_distributed:


### PR DESCRIPTION
Added 2 new metrics: mathews correlation coef. and balanced accuracy.
Added a new functionality to default collate allowing to match the length of some keys in the batch dict to other keys - example: for encoder model, matching the length of the labels to the length of the input after crop padding is applied.