### PR TITLE
Bug fix in `ModularTokenizer.decode()` when the input is `torch.Tensor` type

### DIFF
--- a/fuse/data/tokenizers/modular_tokenizer/modular_tokenizer.py
+++ b/fuse/data/tokenizers/modular_tokenizer/modular_tokenizer.py
@@ -1150,7 +1150,7 @@ class ModularTokenizer(transformers.PreTrainedTokenizerFast):
             str: _description_
         """
         if isinstance(ids, Tensor):
-            # Tokens in 'self.decoder_dict' are integers, and not singletons
+            # Tokens in 'self.decoder_dict' are integers, and not tensors scalars
             ids = ids.tolist()
 
         if skip_special_tokens:

--- a/fuse/data/tokenizers/modular_tokenizer/modular_tokenizer.py
+++ b/fuse/data/tokenizers/modular_tokenizer/modular_tokenizer.py
@@ -1,3 +1,4 @@
+from torch import Tensor
 from typing import Dict
 from collections.abc import Iterable
 from tokenizers import Tokenizer, Encoding
@@ -1148,6 +1149,9 @@ class ModularTokenizer(transformers.PreTrainedTokenizerFast):
         Returns:
             str: _description_
         """
+        if isinstance(ids, Tensor):
+            # Tokens in 'self.decoder_dict' are integers, and not singletons
+            ids = ids.tolist()
 
         if skip_special_tokens:
             ret_val = [


### PR DESCRIPTION
Another "solution" would be to validate that the input value is a list of integers.

The main problem in the current implementation, is that the user is not aware of the type mismatch - the token just appears as missing (!)