### PR TITLE
Restore package name `fuse-med-ml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "fuze-med-ml"
+name = "fuse-med-ml"
 description = "A python framework accelerating ML based discovery in the medical field by encouraging code reuse. Batteries included :)"
 authors = [
 {name = "IBM Research Israel Labs - Machine Learning for Healthcare and Life Sciences"},


### PR DESCRIPTION
so that `pip install "fuse-med-ml @ git+https://github.com/BiomedSciAI/fuse-med-ml.git"` will work again